### PR TITLE
Add support for upstream proxy context

### DIFF
--- a/proxy/director.go
+++ b/proxy/director.go
@@ -13,6 +13,12 @@ import (
 // The presence of the `Context` allows for rich filtering, e.g. based on Metadata (headers).
 // If no handling is meant to be done, a `codes.NotImplemented` gRPC error should be returned.
 //
+// downstreamContext is the context of the client side. downstreamCtx is the context
+// of upstream proxy. upstreamCtx also lives throughout the lifetime of proxying. In cases
+// where clients cancel the connection, upstreamCtx will be canceled but upstreamCtx will continue
+// until all proxying is done. In case of streaming server gRPC, this means when the service
+// call actually terminates.
+//
 // The context returned from this function should be the context for the *outgoing* (to backend) call. In case you want
 // to forward any Metadata between the inbound request and outbound requests, you should do it manually. However, you
 // *must* propagate the cancel function (`context.WithCancel`) of the inbound context to the one returned.
@@ -21,4 +27,4 @@ import (
 // are invoked. So decisions around authorization, monitoring etc. are better to be handled there.
 //
 // See the rather rich example.
-type StreamDirector func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error)
+type StreamDirector func(downstreamCtx, upstreamCtx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error)

--- a/proxy/examples_test.go
+++ b/proxy/examples_test.go
@@ -35,23 +35,23 @@ func ExampleTransparentHandler() {
 // Provide sa simple example of a director that shields internal services and dials a staging or production backend.
 // This is a *very naive* implementation that creates a new connection on every request. Consider using pooling.
 func ExampleStreamDirector() {
-	director = func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+	director = func(downstreamCtx, upstreamCtx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
 		// Make sure we never forward internal services.
 		if strings.HasPrefix(fullMethodName, "/com.example.internal.") {
 			return nil, nil, grpc.Errorf(codes.Unimplemented, "Unknown method")
 		}
-		md, ok := metadata.FromIncomingContext(ctx)
+		md, ok := metadata.FromIncomingContext(downstreamCtx)
 		// Copy the inbound metadata explicitly.
-		outCtx, _ := context.WithCancel(ctx)
+		outCtx, _ := context.WithCancel(downstreamCtx)
 		outCtx = metadata.NewOutgoingContext(outCtx, md.Copy())
 		if ok {
 			// Decide on which backend to dial
 			if val, exists := md[":authority"]; exists && val[0] == "staging.api.example.com" {
 				// Make sure we use DialContext so the dialing can be cancelled/time out together with the context.
-				conn, err := grpc.DialContext(ctx, "api-service.staging.svc.local", grpc.WithCodec(proxy.Codec()))
+				conn, err := grpc.DialContext(downstreamCtx, "api-service.staging.svc.local", grpc.WithCodec(proxy.Codec()))
 				return outCtx, conn, err
 			} else if val, exists := md[":authority"]; exists && val[0] == "api.example.com" {
-				conn, err := grpc.DialContext(ctx, "api-service.prod.svc.local", grpc.WithCodec(proxy.Codec()))
+				conn, err := grpc.DialContext(downstreamCtx, "api-service.prod.svc.local", grpc.WithCodec(proxy.Codec()))
 				return outCtx, conn, err
 			}
 		}


### PR DESCRIPTION
In streaming grpc, current implementation will cancel proxying if downstream (client) context is cancelled even though service side might still be running. In almost all cases this is what you'd want since if client cancels, there is not need to continue proxying.

However in some cases, it may be useful to track service side context as well such that the proxying routine will not terminate until both sides have actually terminated. A typical use-case is to be able to track call completion for resource monitoring purposes.